### PR TITLE
hotfix: not such a dir error fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const ANSIEscape = {
     "reset": `\u001b[0m`,
     "brightpurple": `\u001b[0;95m`
 };
-const config = path.resolve(__dirname, 'config.json');
+const config = process.chdir(__dirname, 'config.json');
 
 function log(message) {
     console.log(`${ANSIEscape.blue}[Launcher]${ANSIEscape.reset} ${message}`);

--- a/index.js
+++ b/index.js
@@ -32,6 +32,8 @@ const ANSIEscape = {
     "reset": `\u001b[0m`,
     "brightpurple": `\u001b[0;95m`
 };
+const config = path.resolve(__dirname, 'config.json');
+
 function log(message) {
     console.log(`${ANSIEscape.blue}[Launcher]${ANSIEscape.reset} ${message}`);
 }
@@ -343,7 +345,7 @@ function launch(filePath, recursive) {
     }
 }
 function init() {
-    let settings = parseJSONC(fs.readFileSync("config.json", "utf-8"));
+    let settings = parseJSONC(fs.readFileSync(config, "utf-8"));
     for (let [version, jarName] of Object.entries(settings.mindustryJars.customVersionNames)) {
         if (jarName.includes(" ")) {
             error(`Jar name for version ${version} contains a space.`);


### PR DESCRIPTION
This is Hotfix of index.js

i launched the index.js but i found the problem, there is no such a file of config.json

```
C:\Mindustry\Launcher>node .
[Launcher] Unhandled runtime error!
C:\Mindustry\Launcher\index.js:514
    throw err;
    ^

Error: ENOENT: no such file or directory, open 'config.json'
    at Object.openSync (node:fs:585:3)
    at Object.readFileSync (node:fs:453:35)
    at init (C:\Mindustry\Launcher\index.js:346:34)
    at main (C:\Mindustry\Launcher\index.js:432:28)
    at Object.<anonymous> (C:\Mindustry\Launcher\index.js:510:5)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1157:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12) {
  errno: -4058,
  syscall: 'open',
  code: 'ENOENT',
  path: 'config.json'
}```

i fixed it with __dirname and create those own const it work